### PR TITLE
update tag splitting and strip whitespace

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -42,7 +42,10 @@ module.exports = yeoman.generators.Base.extend({
     this.prompt(prompts, function (props) {
       var tags = props.tags || '';
       this.props = props;
-      this.props.tags = tags.split(/,?\s+/);
+      this.props.tags = tags.split(',');
+      this.props.tags.forEach(function (tag, index, tagsArray){
+        tagsArray[index] = tag.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
+      });
       done();
     }.bind(this));
   },


### PR DESCRIPTION
I just updated the RegEx to first split the tags by the comma then strip only whitespace _before_ and _after_ the strings. 

`abc,def, ghi , jk l`
Now returns the tags in the correct format in the `.yml` eg:
````yml
tags:
- abc
- def
- ghi
- jk l
```
Only a small change but it might help. :smile: 